### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "express": "4.15.0",  
     "lodash": "4.17.20",
-    "escape-html": "^1.0.3"
+    "escape-html": "^1.0.3",
+    "express-rate-limit": "^7.5.0"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Potential fix for [https://github.com/nanzgdemo/onemoretime/security/code-scanning/1](https://github.com/nanzgdemo/onemoretime/security/code-scanning/1)

To fix the problem, we need to introduce rate limiting to the Express application. This can be achieved by using the `express-rate-limit` middleware. We will set up a rate limiter that restricts the number of requests a client can make within a specified time window. This will help prevent denial-of-service attacks by limiting the rate at which requests are accepted.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `vulnerable.js` file.
3. Set up a rate limiter with a reasonable limit (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the `/login` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
